### PR TITLE
Fix renderer network error handler

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -11,6 +11,6 @@ window.electronAPI.onNetworkSpeed((event, data) => {
   document.getElementById("download").textContent = data.downloadSpeed;
   document.getElementById("error-message").textContent = "";
 });
-window.api.onNetworkError((error) => {
+window.electronAPI.onNetworkError((error) => {
   document.getElementById("error-message").textContent = `错误: ${error}`;
 });


### PR DESCRIPTION
## Summary
- update renderer.js to listen for network errors using `window.electronAPI`

## Testing
- `npm run start` *(fails: electron not found)*