### PR TITLE
Add Jest tests for selectPrimaryInterface

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,3 +109,7 @@ app.on("window-all-closed", function () {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+
+module.exports = {
+  selectPrimaryInterface,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A minimal Electron application",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "jest"
   },
   "repository": "https://github.com/electron/electron-quick-start",
   "keywords": [
@@ -17,7 +18,8 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^36.2.1"
+    "electron": "^36.2.1",
+    "jest": "^29.6.1"
   },
   "dependencies": {
     "bytes": "^3.1.2",

--- a/tests/selectPrimaryInterface.test.js
+++ b/tests/selectPrimaryInterface.test.js
@@ -1,0 +1,25 @@
+const { selectPrimaryInterface } = require('../main');
+
+describe('selectPrimaryInterface', () => {
+  test('returns first active non-virtual interface with data transfer', () => {
+    const stats = [
+      { iface: 'eth0', operstate: 'down', virtual: false, rx_bytes: 0, tx_bytes: 0 },
+      { iface: 'lo', operstate: 'up', virtual: true, rx_bytes: 100, tx_bytes: 100 },
+      { iface: 'wifi0', operstate: 'up', virtual: false, rx_bytes: 50, tx_bytes: 60 },
+      { iface: 'wifi1', operstate: 'up', virtual: false, rx_bytes: 0, tx_bytes: 0 }
+    ];
+
+    const result = selectPrimaryInterface(stats);
+    expect(result.iface).toBe('wifi0');
+  });
+
+  test('defaults to first interface if none match', () => {
+    const stats = [
+      { iface: 'eth0', operstate: 'down', virtual: false, rx_bytes: 0, tx_bytes: 0 },
+      { iface: 'wifi1', operstate: 'up', virtual: false, rx_bytes: 0, tx_bytes: 0 }
+    ];
+
+    const result = selectPrimaryInterface(stats);
+    expect(result.iface).toBe('eth0');
+  });
+});


### PR DESCRIPTION
## Summary
- export `selectPrimaryInterface` from `main.js`
- add Jest dependency and test script
- create `tests` directory with `selectPrimaryInterface.test.js`

## Testing
- `npm test` *(fails: jest not found)*