### PR TITLE
Refactor selectPrimaryInterface into util and document tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const { app, BrowserWindow } = require("electron");
 const si = require("systeminformation");
 const path = require("node:path");
 const bytes = require("bytes");
+const { selectPrimaryInterface } = require("./networkUtils");
 
 let mainWindow;
 function createWindow() {
@@ -25,18 +26,6 @@ function createWindow() {
 }
 // 存储上一次获取到的网络接口数据，用于计算速度的差值
 let lastNetworkStats = null;
-
-// 选择当前主用的网络接口（已启用、非虚拟接口且存在数据传输）
-function selectPrimaryInterface(stats) {
-  return (
-    stats.find(
-      (iface) =>
-        iface.operstate === "up" && // 接口状态为启用（up）
-        !iface.virtual && // 非虚拟网络接口
-        (iface.rx_bytes > 0 || iface.tx_bytes > 0) // 存在数据传输
-    ) || stats[0] // 若未找到符合条件的接口，则默认使用第一个接口
-  );
-}
 
 // 周期性地获取网络接口数据并计算当前网速
 async function getNetworkSpeed() {
@@ -109,3 +98,4 @@ app.on("window-all-closed", function () {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+

--- a/networkUtils.js
+++ b/networkUtils.js
@@ -1,0 +1,27 @@
+// Utility functions related to network interfaces
+// This module exports selectPrimaryInterface so it can be tested
+
+/**
+ * Choose the primary network interface from a list of stats.
+ * The preferred interface is:
+ *   - operstate === 'up'
+ *   - not virtual
+ *   - has transmitted or received data
+ * If none match, the first interface is returned.
+ * @param {Array<Object>} stats array of network stats from systeminformation
+ * @returns {Object} the chosen interface
+ */
+function selectPrimaryInterface(stats) {
+  return (
+    stats.find(
+      (iface) =>
+        iface.operstate === 'up' &&
+        !iface.virtual &&
+        (iface.rx_bytes > 0 || iface.tx_bytes > 0)
+    ) || stats[0]
+  );
+}
+
+module.exports = {
+  selectPrimaryInterface,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A minimal Electron application",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "jest"
   },
   "repository": "https://github.com/electron/electron-quick-start",
   "keywords": [
@@ -17,7 +18,8 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^36.2.1"
+    "electron": "^36.2.1",
+    "jest": "^29.6.1"
   },
   "dependencies": {
     "bytes": "^3.1.2",

--- a/tests/selectPrimaryInterface.test.js
+++ b/tests/selectPrimaryInterface.test.js
@@ -1,0 +1,35 @@
+// Import the helper we want to test. It is kept in a separate module
+// so that main.js (the Electron entry file) doesn't need to export it.
+const { selectPrimaryInterface } = require('../networkUtils');
+
+describe('selectPrimaryInterface', () => {
+  test('returns first active non-virtual interface with data transfer', () => {
+    // Simulated list of network interfaces returned by systeminformation
+    const stats = [
+      // Interface that is down should be ignored
+      { iface: 'eth0', operstate: 'down', virtual: false, rx_bytes: 0, tx_bytes: 0 },
+      // Loopback is up but virtual, so should also be ignored
+      { iface: 'lo', operstate: 'up', virtual: true, rx_bytes: 100, tx_bytes: 100 },
+      // This interface is up, not virtual and has traffic -> should be selected
+      { iface: 'wifi0', operstate: 'up', virtual: false, rx_bytes: 50, tx_bytes: 60 },
+      // Up and non-virtual but no traffic yet
+      { iface: 'wifi1', operstate: 'up', virtual: false, rx_bytes: 0, tx_bytes: 0 }
+    ];
+
+    // Execute the helper and verify the expected interface is chosen
+    const result = selectPrimaryInterface(stats);
+    expect(result.iface).toBe('wifi0');
+  });
+
+  test('defaults to first interface if none match', () => {
+    // No interface meets the "active non-virtual with traffic" criteria
+    const stats = [
+      { iface: 'eth0', operstate: 'down', virtual: false, rx_bytes: 0, tx_bytes: 0 },
+      { iface: 'wifi1', operstate: 'up', virtual: false, rx_bytes: 0, tx_bytes: 0 }
+    ];
+
+    // In this scenario the function should return the first interface
+    const result = selectPrimaryInterface(stats);
+    expect(result.iface).toBe('eth0');
+  });
+});


### PR DESCRIPTION
## Summary
- move `selectPrimaryInterface` to `networkUtils.js`
- import helper from `networkUtils` in `main.js`
- add detailed comments inside `selectPrimaryInterface.test.js`

## Testing
- `npm test` *(fails: jest not found)*